### PR TITLE
fix: s3 only routes are not handled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use browse::list;
 use common::{Config, IntelMission, Metrics};
 use error::{Error, Result};
 use queue::queue_length;
-use repos::{index, repo_routes};
+use repos::{configure_repo_routes, index};
 use storage::check_s3;
 use utils::not_found;
 
@@ -154,6 +154,7 @@ async fn main() {
         App::new()
             .app_data(web::Data::new(mission.clone()))
             .app_data(web::Data::from(config.clone()))
+            .route("/metrics", web::get().to(metrics_endpoint))
             .route(
                 "/{path:.*}",
                 web::get()
@@ -162,8 +163,7 @@ async fn main() {
                     }))
                     .to(list),
             )
-            .route("/metrics", web::get().to(metrics_endpoint))
-            .service(repo_routes())
+            .configure(configure_repo_routes)
             .route("/{path:.*}", web::get().to(index))
             .default_service(web::route().to(not_found))
             .wrap_fn(queue_length)

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,5 +1,5 @@
 use actix_web::http::{Method, Uri};
-use actix_web::{guard, web, HttpResponse, Route, Scope};
+use actix_web::{guard, web, HttpResponse, Route};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -173,8 +173,8 @@ pub fn gradle_allow(_config: &Config, path: &str) -> bool {
     path.ends_with(".zip")
 }
 
-pub fn repo_routes() -> Scope {
-    web::scope("")
+pub fn configure_repo_routes(config: &mut web::ServiceConfig) {
+    config
         .route(
             "/crates.io/{path:.+}",
             simple_intel(|c| &c.crates_io, "crates.io", allow_all, disallow_all),
@@ -296,7 +296,7 @@ pub fn repo_routes() -> Scope {
         .route(
             "/nix-channels/store/{path:.+}",
             nix_intel(|c| &c.nix_channels_store, "nix-channels/store"),
-        )
+        );
 }
 
 pub async fn dart_pub(


### PR DESCRIPTION
A scope handler will cause actix to ignore all later handlers with the same prefix, causing s3-only routes to be handled by the repo scope, and a 404 is returned.

This is also the correct fix for the metrics endpoint.